### PR TITLE
feat: 워렌 버핏 투자 철학 기반 챗봇 및 리포트 기능 추가

### DIFF
--- a/simple_fast_api/cache.py
+++ b/simple_fast_api/cache.py
@@ -64,3 +64,4 @@ quarterly_financials_cache = DiskCache(os.path.join(_CACHE_DIR, "quarterly_finan
 quarterly_dividend_cache   = DiskCache(os.path.join(_CACHE_DIR, "quarterly_dividend"),   max_size=20)
 valuation_cache            = DiskCache(os.path.join(_CACHE_DIR, "valuation"),            max_size=20)
 report_cache               = DiskCache(os.path.join(_CACHE_DIR, "report"),               max_size=10)
+buffett_report_cache       = DiskCache(os.path.join(_CACHE_DIR, "buffett_report"),       max_size=10)

--- a/simple_fast_api/main.py
+++ b/simple_fast_api/main.py
@@ -38,9 +38,9 @@ import database
 import bot as telegram_bot
 from cache import (dividend_cache, financials_cache, dividend_json_cache, business_cache,
                    quarterly_financials_cache, quarterly_dividend_cache, valuation_cache,
-                   report_cache)
+                   report_cache, buffett_report_cache)
 from services.valuation import fetch_valuation
-from services.report import generate_report
+from services.report import generate_report, generate_buffett_report
 from services.chat import build_system_context, chat_with_gemini
 from services.dart import (get_corp_code, fetch_dart_financials, fetch_dividend_per_share,
                             fetch_dart_financials_q, fetch_dividend_per_share_q,
@@ -701,14 +701,69 @@ async def get_report(company_name: str):
     return JSONResponse(content={**result, 'cached': False})
 
 
+@app.get("/buffett-report/{company_name}")
+async def get_buffett_report(company_name: str):
+    """워렌 버핏 투자 철학을 적용한 종합 투자 리포트를 생성합니다.
+    경제적 해자, 내재가치, 안전마진 관점에서 분석합니다."""
+    cached = buffett_report_cache.get(company_name)
+    if cached is not None:
+        print(f"[Cache] '{company_name}' 버핏 리포트 캐시 히트")
+        return JSONResponse(content={**cached, 'cached': True})
+
+    corp_code = await asyncio.to_thread(get_corp_code, company_name)
+    current_year = datetime.now().year
+
+    def fetch_filings_sync():
+        res = requests.get(
+            "https://opendart.fss.or.kr/api/list.json",
+            params={
+                'crtfc_key': DART_API_KEY, 'corp_code': corp_code,
+                'bgn_de': f"{current_year - 1}0101",
+                'end_de': f"{current_year}1231",
+                'sort': 'date', 'sort_mth': 'desc', 'page_count': 10,
+            },
+            timeout=15,
+        )
+        data = res.json()
+        return data.get('list', []) if data.get('status') == '000' else []
+
+    biz_result, filings, fin_all = await asyncio.gather(
+        asyncio.to_thread(fetch_business_overview, corp_code, company_name),
+        asyncio.to_thread(fetch_filings_sync),
+        asyncio.gather(
+            *[asyncio.to_thread(fetch_dart_financials, corp_code, str(y))
+              for y in range(current_year - 1, current_year - 6, -1)],
+            return_exceptions=True,
+        ),
+        return_exceptions=True,
+    )
+
+    business_sections = biz_result.get('sections', []) if isinstance(biz_result, dict) else []
+    recent_filings    = filings if isinstance(filings, list) else []
+    financials        = [f for f in (fin_all if isinstance(fin_all, (list, tuple)) else []) if isinstance(f, dict)]
+    dividends         = (dividend_cache.get(company_name) or {}).get('dividend_data', [])
+    valuation         = valuation_cache.get(company_name)
+
+    report_text = await generate_buffett_report(
+        company_name, business_sections, financials, dividends, valuation, recent_filings
+    )
+
+    result = {'company_name': company_name, 'report': report_text, 'mode': 'buffett'}
+    buffett_report_cache.set(company_name, result)
+    print(f"[Cache] '{company_name}' 버핏 리포트 캐시 저장")
+    return JSONResponse(content={**result, 'cached': False})
+
+
 class ChatRequest(BaseModel):
     message: str
     history: list[dict] = []
+    mode: str = "general"   # "general" | "buffett"
 
 
 @app.post("/chat/{company_name}")
 async def chat(company_name: str, req: ChatRequest):
-    """공시 데이터를 컨텍스트로 Gemini AI와 멀티턴 상담을 수행합니다."""
+    """공시 데이터를 컨텍스트로 Gemini AI와 멀티턴 상담을 수행합니다.
+    mode="buffett" 시 워렌 버핏 투자 철학 기반으로 답변합니다."""
     corp_code = await asyncio.to_thread(get_corp_code, company_name)
     current_year = datetime.now().year
 
@@ -760,11 +815,16 @@ async def chat(company_name: str, req: ChatRequest):
     dividends         = (dividend_cache.get(company_name) or {}).get('dividend_data', [])
     valuation         = valuation_cache.get(company_name)
 
+    buffett_mode = req.mode == "buffett"
     system_context = build_system_context(
-        company_name, business_sections, financials, dividends, valuation, filings
+        company_name, business_sections, financials, dividends, valuation, filings,
+        buffett_mode=buffett_mode,
     )
-    answer = await chat_with_gemini(system_context, req.history, req.message, company_name)
-    return JSONResponse(content={"answer": answer})
+    answer = await chat_with_gemini(
+        system_context, req.history, req.message, company_name,
+        buffett_mode=buffett_mode,
+    )
+    return JSONResponse(content={"answer": answer, "mode": req.mode})
 
 
 @app.get("/cache/status")
@@ -778,6 +838,8 @@ async def cache_status():
         "quarterly_financials": quarterly_financials_cache.info(),
         "quarterly_dividend": quarterly_dividend_cache.info(),
         "valuation": valuation_cache.info(),
+        "report": report_cache.info(),
+        "buffett_report": buffett_report_cache.info(),
     })
 
 
@@ -794,6 +856,8 @@ async def cache_clear(company_name: str = None):
             financials_cache.clear(company_name),
             dividend_json_cache.clear(company_name),
             business_cache.clear(company_name),
+            report_cache.clear(company_name),
+            buffett_report_cache.clear(company_name),
         ])
         if not removed:
             raise HTTPException(status_code=404, detail=f"'{company_name}'의 캐시 데이터가 없습니다.")
@@ -803,6 +867,8 @@ async def cache_clear(company_name: str = None):
         financials_cache.clear()
         dividend_json_cache.clear()
         business_cache.clear()
+        report_cache.clear()
+        buffett_report_cache.clear()
         return {"message": "전체 캐시가 삭제되었습니다."}
 
 

--- a/simple_fast_api/services/chat.py
+++ b/simple_fast_api/services/chat.py
@@ -10,6 +10,72 @@ GEMINI_URL = (
     ":generateContent?key={key}"
 )
 
+# ── 워렌 버핏 투자 철학 시스템 프롬프트 ──────────────────────────────────────
+BUFFETT_SYSTEM_PROMPT = """당신은 워렌 버핏의 투자 철학을 완벽히 체화한 투자 분석가입니다.
+아래 원칙과 제공된 DART 공시 데이터를 함께 활용해 모든 투자 질문에 답변하세요.
+
+## 핵심 투자 원칙
+
+### 1. 기업 가치 (Intrinsic Value)
+- 주식은 기업의 일부 소유권이다. 주가가 아닌 기업을 산다.
+- 내재가치(Intrinsic Value) = 미래 현금흐름의 현재가치(DCF)
+- "가격은 당신이 지불하는 것, 가치는 당신이 얻는 것"
+
+### 2. 안전마진 (Margin of Safety)
+- 내재가치 대비 30~50% 이상 할인된 가격에만 매수
+- 불확실성에 대한 버퍼 확보가 핵심
+
+### 3. 경제적 해자 (Economic Moat)
+- 브랜드 파워, 전환 비용, 네트워크 효과, 원가 우위
+- 해자 없는 기업은 장기 보유 불가
+
+### 4. 경영진 신뢰성
+- 자본 배분 능력이 뛰어난 경영진
+- 주주 친화적 지표: ROE, 자사주 매입, 배당
+- "훌륭한 경영진이 망가진 사업을 구할 수 없다"
+
+### 5. 장기 보유
+- 보유 기간: 영원히 (기업 가치 유지 시)
+- 단기 주가 변동은 무시, 복리의 마법을 최대한 활용
+
+### 6. 능력 범위 (Circle of Competence)
+- 이해하지 못하는 사업에는 투자하지 않는다
+
+### 7. 역발상 투자
+- "남들이 탐욕스러울 때 두려워하고, 남들이 두려워할 때 탐욕스러워라"
+
+## 분석 프레임워크
+질문을 받으면 아래 순서로 답변하세요:
+1. 핵심 사업 이해 (제공된 사업 개요 데이터 활용)
+2. 경제적 해자 존재 여부 판단
+3. 재무 건전성 및 내재가치 추정 (ROE, FCF, 부채비율 데이터 활용)
+4. 안전마진 여부 판단 (PBR, PER 등 밸류에이션 데이터 활용)
+5. 최종 버핏식 의견
+
+## 말투/스타일
+- 버핏의 주주 서한처럼 쉬운 언어로 복잡한 개념 설명
+- 야구, 농구 등 비유를 자주 사용
+- 한국어로 답변
+- 핵심 수치(재무 데이터)를 반드시 인용하며 근거를 제시
+"""
+
+BUFFETT_FEW_SHOT_USER = """## 버핏 스타일 답변 예시
+
+Q: 삼성전자 지금 사도 될까요?
+A: 먼저 사업을 이해해야 합니다. 삼성전자는 반도체(HBM, DRAM), 스마트폰, 가전이라는 세 개의 엔진을 가진 기업입니다.
+해자 관점에서는 반도체 기술력과 제조 규모의 원가 우위가 있지만, 사이클 산업이라는 점에서 해자의 지속성은 제한적입니다.
+내재가치 추정 시 반도체 사이클 정상화 이익을 기준으로 PBR 1.0배 이하라면 안전마진이 충분하다고 볼 수 있습니다.
+단, 저라면 "10년 뒤 이 회사가 지금보다 더 많은 돈을 벌고 있을까?"를 먼저 자문합니다.
+
+Q: 단기 트레이딩으로 수익 내는 방법이 뭔가요?
+A: 저는 그 게임을 하지 않습니다. 단기 시세 예측은 저의 능력 범위(Circle of Competence) 밖입니다.
+훌륭한 기업을 적정 가격에 사서 오래 보유하는 것, 그것이 제가 60년간 해온 전부입니다.
+
+위 예시를 참고하여 버핏의 관점으로 분석하겠습니다."""
+
+BUFFETT_FEW_SHOT_MODEL = """네, 워렌 버핏의 투자 철학과 제공된 DART 공시 데이터를 바탕으로 분석해 드리겠습니다.
+기업의 본질적 가치, 경제적 해자, 안전마진을 중심으로 답변드리겠습니다. 무엇이 궁금하신가요?"""
+
 
 def _url() -> str:
     return GEMINI_URL.format(key=os.getenv("GEMINI_API_KEY", ""))
@@ -34,6 +100,7 @@ def build_system_context(
     dividends: list[dict],
     valuation: dict | None,
     recent_filings: list[dict],
+    buffett_mode: bool = False,
 ) -> str:
     """회사 공시 데이터를 Gemini 시스템 컨텍스트 문자열로 변환합니다."""
 
@@ -78,14 +145,7 @@ def build_system_context(
     for f in recent_filings[:10]:
         filing_text += f"  - {f.get('rcept_dt', '')} {f.get('report_nm', '')}\n"
 
-    return f"""당신은 "{company_name}"의 DART 공시 데이터를 기반으로 투자 상담을 제공하는 전문 애널리스트입니다.
-
-아래 데이터만을 근거로 사용자의 질문에 답변하세요.
-데이터에 없는 내용은 "공시된 데이터에 해당 정보가 없습니다"라고 답하세요.
-투자 결정은 항상 투자자 본인의 판단임을 강조하세요.
-답변은 간결하고 명확하게, 핵심 수치를 인용하며 작성하세요.
-
-=== {company_name} 사업 개요 ===
+    data_context = f"""=== {company_name} 사업 개요 ===
 {biz_text}
 
 === 재무 지표 (최근 5개년) ===
@@ -101,12 +161,33 @@ def build_system_context(
 {filing_text}
 """
 
+    if buffett_mode:
+        return f"""{BUFFETT_SYSTEM_PROMPT}
+
+아래는 분석 대상 기업 "{company_name}"의 DART 공시 데이터입니다.
+이 데이터를 워렌 버핏의 투자 원칙에 따라 분석하세요.
+
+{data_context}
+데이터에 없는 내용은 "공시된 데이터에 해당 정보가 없습니다"라고 답하세요.
+"""
+
+    return f"""당신은 "{company_name}"의 DART 공시 데이터를 기반으로 투자 상담을 제공하는 전문 애널리스트입니다.
+
+아래 데이터만을 근거로 사용자의 질문에 답변하세요.
+데이터에 없는 내용은 "공시된 데이터에 해당 정보가 없습니다"라고 답하세요.
+투자 결정은 항상 투자자 본인의 판단임을 강조하세요.
+답변은 간결하고 명확하게, 핵심 수치를 인용하며 작성하세요.
+
+{data_context}
+"""
+
 
 async def chat_with_gemini(
     system_context: str,
     history: list[dict],
     user_message: str,
     company_name: str = "",
+    buffett_mode: bool = False,
 ) -> str:
     """
     Gemini 멀티턴 대화를 수행합니다.
@@ -115,15 +196,26 @@ async def chat_with_gemini(
     """
     contents = []
 
-    # 시스템 컨텍스트를 첫 user/model 턴으로 삽입
-    contents.append({
-        "role": "user",
-        "parts": [{"text": f"[시스템 컨텍스트]\n{system_context}\n\n위 데이터를 바탕으로 투자 상담을 시작합니다."}]
-    })
-    contents.append({
-        "role": "model",
-        "parts": [{"text": f"네, {company_name}의 DART 공시 데이터를 바탕으로 질문에 답변드리겠습니다. 무엇이 궁금하신가요?"}]
-    })
+    if buffett_mode:
+        # 버핏 모드: 시스템 컨텍스트 + few-shot 예시를 첫 턴으로 삽입
+        contents.append({
+            "role": "user",
+            "parts": [{"text": f"[시스템 컨텍스트]\n{system_context}\n\n{BUFFETT_FEW_SHOT_USER}"}]
+        })
+        contents.append({
+            "role": "model",
+            "parts": [{"text": BUFFETT_FEW_SHOT_MODEL}]
+        })
+    else:
+        # 일반 모드
+        contents.append({
+            "role": "user",
+            "parts": [{"text": f"[시스템 컨텍스트]\n{system_context}\n\n위 데이터를 바탕으로 투자 상담을 시작합니다."}]
+        })
+        contents.append({
+            "role": "model",
+            "parts": [{"text": f"네, {company_name}의 DART 공시 데이터를 바탕으로 질문에 답변드리겠습니다. 무엇이 궁금하신가요?"}]
+        })
 
     # 이전 대화 이력
     for msg in history:

--- a/simple_fast_api/services/report.py
+++ b/simple_fast_api/services/report.py
@@ -142,3 +142,126 @@ async def generate_report(
             res.raise_for_status()
             data = await res.json()
             return data["candidates"][0]["content"]["parts"][0]["text"]
+
+
+def _build_buffett_prompt(
+    company_name: str,
+    business_sections: list[dict],
+    financials: list[dict],
+    dividends: list[dict],
+    valuation: dict | None,
+    recent_filings: list[dict],
+) -> str:
+    """워렌 버핏 투자 철학 기반 리포트 프롬프트를 생성합니다."""
+    # 사업 개요 (1~2항만 요약)
+    biz_text = ""
+    for sec in business_sections[:2]:
+        blocks = sec.get("blocks", [])
+        text_parts = [b["content"] for b in blocks if b.get("type") == "text" and b.get("content")]
+        combined = " ".join(text_parts)[:800]
+        biz_text += f"\n[{sec['number']}. {sec['title']}]\n{combined}\n"
+
+    # 재무 테이블
+    fin_rows = ""
+    for f in financials[-5:]:
+        fin_rows += (
+            f"  {f['year']}년 | 매출 {_fmt_krw(f.get('revenue'))} | "
+            f"영업이익 {_fmt_krw(f.get('operating_income'))} | "
+            f"당기순이익 {_fmt_krw(f.get('net_income'))} | "
+            f"ROE {f.get('roe') or 'N/A'}% | "
+            f"부채비율 {f.get('debt_ratio') or 'N/A'}% | "
+            f"FCF {_fmt_krw(f.get('fcf'))}\n"
+        )
+
+    # 배당 이력
+    div_rows = ""
+    for d in dividends[-5:]:
+        div_rows += f"  {d.get('year')}년: 주당 {d.get('dividend', 0):,}원\n"
+
+    # 밸류에이션
+    val_text = "N/A"
+    if valuation:
+        val_text = (
+            f"현재가 {valuation.get('price', 0):,.0f}원 | "
+            f"시가총액 {_fmt_krw(valuation.get('market_cap'))} | "
+            f"PER {valuation.get('per') or 'N/A'}x | "
+            f"PBR {valuation.get('pbr') or 'N/A'}x | "
+            f"PSR {valuation.get('psr') or 'N/A'}x | "
+            f"EV/EBIT {valuation.get('ev_ebit') or 'N/A'}x"
+        )
+
+    return f"""당신은 워렌 버핏의 투자 철학을 완벽히 체화한 투자 분석가입니다.
+아래 DART 공시 데이터를 기반으로 "{company_name}"에 대한 버핏 스타일 투자 리포트를 작성하세요.
+
+## 버핏 투자 원칙 체크리스트 (분석 시 반드시 적용)
+- 경제적 해자(Economic Moat): 브랜드, 전환비용, 네트워크 효과, 원가 우위
+- 내재가치(Intrinsic Value): ROE 지속성, FCF 창출 능력, 이익 성장 추세
+- 안전마진(Margin of Safety): PBR, PER이 내재가치 대비 충분히 낮은가
+- 경영진 신뢰성: ROE 추세, 자본 배분 효율성
+- 능력 범위: 사업 구조가 이해 가능한가
+
+=== 사업 개요 ===
+{biz_text}
+
+=== 재무 지표 (최근 5개년) ===
+{fin_rows}
+
+=== 배당 이력 ===
+{div_rows}
+
+=== 현재 밸류에이션 ===
+{val_text}
+
+---
+위 데이터를 분석하여 아래 형식으로 버핏 스타일 리포트를 작성하세요.
+각 항목은 2~4문장으로 핵심만 간결하게, 실제 수치를 인용하며 작성하세요.
+버핏의 주주 서한처럼 쉽고 직관적인 언어를 사용하고, 비유를 적극 활용하세요.
+
+## {company_name} — 워렌 버핏 스타일 투자 리포트
+
+### 1. 사업 이해 (Circle of Competence)
+(이 사업을 10살 어린이에게 설명할 수 있는가? 핵심 수익 구조 요약)
+
+### 2. 경제적 해자 (Economic Moat)
+(해자 종류와 강도 평가: 강함 / 보통 / 약함 / 없음, 근거 제시)
+
+### 3. 재무 건전성 및 내재가치
+(ROE 지속성, FCF 창출, 부채 수준으로 내재가치 방향성 판단)
+
+### 4. 안전마진 (Margin of Safety)
+(현재 PBR·PER 기준 저평가/적정/고평가 여부, 매수 가능 가격대 제시)
+
+### 5. 배당 및 주주 환원
+(배당 지속성, 배당 성향, 버핏식 배당 재투자 관점 평가)
+
+### 6. 주요 리스크
+(버핏이 가장 우려할 리스크 2~3가지)
+
+### 7. 버핏의 최종 의견
+**[매수 적극 고려 / 적정 가격 대기 / 관심 종목 보류 / 투자 부적합]**
+(한 문단 — "만약 내가 이 주식을 10년 보유해야 한다면..." 형식으로 작성)
+
+---
+*본 리포트는 워렌 버핏의 투자 철학을 AI가 적용한 참고 자료이며, 투자 결정의 책임은 투자자 본인에게 있습니다.*
+"""
+
+
+async def generate_buffett_report(
+    company_name: str,
+    business_sections: list[dict],
+    financials: list[dict],
+    dividends: list[dict],
+    valuation: dict | None,
+    recent_filings: list[dict],
+) -> str:
+    """워렌 버핏 투자 철학 기반 종합 투자 리포트를 생성합니다."""
+    prompt = _build_buffett_prompt(
+        company_name, business_sections, financials, dividends, valuation, recent_filings
+    )
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(_gemini_url(), json=payload, timeout=aiohttp.ClientTimeout(total=60)) as res:
+            res.raise_for_status()
+            data = await res.json()
+            return data["candidates"][0]["content"]["parts"][0]["text"]


### PR DESCRIPTION
- services/chat.py: BUFFETT_SYSTEM_PROMPT와 few-shot 예시 추가,
  build_system_context/chat_with_gemini에 buffett_mode 파라미터 지원
- services/report.py: generate_buffett_report() 함수 추가 (해자·내재가치·안전마진 분석)
- cache.py: buffett_report_cache 추가
- main.py: ChatRequest에 mode 필드 추가("general"|"buffett"),
  GET /buffett-report/{company_name} 엔드포인트 추가,
  캐시 status/clear에 report·buffett_report 포함

https://claude.ai/code/session_0139Gp8FFWX7MES3nhG6JWp5