### PR TITLE
feat: 주가 그래프에 뉴스·공시 이벤트 마커 연동

### DIFF
--- a/frontend/next/src/app/events/page.tsx
+++ b/frontend/next/src/app/events/page.tsx
@@ -1,9 +1,25 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
 import { ProgressIndicator } from '@/components/ProgressIndicator';
 import { useDartData } from '@/lib/useDartData';
+
+ChartJS.register(
+  CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler,
+);
 
 interface Source {
   title: string;
@@ -12,6 +28,7 @@ interface Source {
 
 interface PriceEvent {
   date: string;
+  anchor_date: string | null;
   pct_change: number | null;
   headline: string;
   summary: string;
@@ -20,8 +37,14 @@ interface PriceEvent {
   sources: Source[];
 }
 
+interface PricePoint {
+  date: string;
+  close: number;
+}
+
 interface EventsData {
   events: PriceEvent[];
+  prices: PricePoint[];
 }
 
 const PAGE_KEY = 'events';
@@ -32,6 +55,9 @@ const EVENT_STEPS = [
   { label: 'AI가 밸류에이션·내러티브 관점에서 사건을 선별하는 중',   after: 3_000 },
   { label: '거의 다 됐어요, 조금만 더 기다려주세요',                after: 10_000 },
 ];
+
+const HIGH_COLOR = '#d97706';   // amber-600
+const MEDIUM_COLOR = '#3b82f6'; // blue-500
 
 interface Props {
   toggleFavorite?: (company: string, page: string) => void;
@@ -56,13 +82,23 @@ function PctBadge({ pct }: { pct: number | null }) {
   );
 }
 
-function EventCard({ event }: { event: PriceEvent }) {
-  const [open, setOpen] = useState(false);
-
+function EventCard({
+  event,
+  open,
+  onToggle,
+}: {
+  event: PriceEvent;
+  open: boolean;
+  onToggle: () => void;
+}) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+    <div
+      className={`bg-white rounded-xl shadow-sm border overflow-hidden transition-colors ${
+        open ? 'border-blue-300 ring-1 ring-blue-200' : 'border-gray-100'
+      }`}
+    >
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={onToggle}
         className="w-full flex items-start gap-4 px-5 py-4 text-left hover:bg-gray-50 transition-colors"
       >
         <div className="flex-shrink-0 text-xs text-gray-400 pt-0.5 w-24">
@@ -118,11 +154,141 @@ export default function EventsPage({
     useDartData<EventsData>(
       {
         buildPath: (n) => `/events/${n}`,
-        extractData: (j: any) => ({ events: j.events ?? [] }),
+        extractData: (j: any) => ({ events: j.events ?? [], prices: j.prices ?? [] }),
       },
       initialCompany,
       onSearched,
     );
+
+  // 차트 마커 ↔ 카드 선택 상태 (양방향 연동)
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 새 회사 검색 시 선택 초기화
+  React.useEffect(() => {
+    setSelectedIdx(null);
+  }, [resolvedName]);
+
+  // 가격 시계열 + 이벤트 마커를 하나의 라인 차트 데이터로 구성한다.
+  const chart = useMemo(() => {
+    if (!data || data.prices.length === 0) return null;
+
+    const labels = data.prices.map((p) => p.date);
+    const closes = data.prices.map((p) => p.close);
+    const dateIndex = new Map(labels.map((d, i) => [d, i]));
+
+    // 각 거래일 인덱스에 매칭되는 이벤트(있으면). 같은 날 충돌 시 먼저 온(중요도 높은) 이벤트 유지.
+    const markerEvent: (PriceEvent | null)[] = labels.map(() => null);
+    const markerEventIdx: (number | null)[] = labels.map(() => null);
+    data.events.forEach((ev, evIdx) => {
+      const anchor = ev.anchor_date ?? ev.date;
+      const i = dateIndex.get(anchor);
+      if (i != null && markerEvent[i] == null) {
+        markerEvent[i] = ev;
+        markerEventIdx[i] = evIdx;
+      }
+    });
+
+    const markerData = labels.map((_, i) => (markerEvent[i] ? closes[i] : null));
+    const markerRadius = labels.map((_, i) => {
+      if (markerEventIdx[i] == null) return 0;
+      return markerEventIdx[i] === selectedIdx ? 9 : 5;
+    });
+    const markerColor = labels.map((_, i) => {
+      const ev = markerEvent[i];
+      if (!ev) return 'transparent';
+      return ev.importance === 'high' ? HIGH_COLOR : MEDIUM_COLOR;
+    });
+
+    const chartData = {
+      labels,
+      datasets: [
+        {
+          label: '종가 (원)',
+          data: closes,
+          borderColor: 'rgba(107, 114, 128, 0.9)',
+          backgroundColor: 'rgba(107, 114, 128, 0.08)',
+          borderWidth: 1.5,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          tension: 0.1,
+          fill: true,
+          order: 2,
+        },
+        {
+          label: '사건',
+          data: markerData,
+          showLine: false,
+          pointRadius: markerRadius,
+          pointHoverRadius: markerRadius.map((r) => (r > 0 ? r + 2 : 0)),
+          pointBackgroundColor: markerColor,
+          pointBorderColor: '#ffffff',
+          pointBorderWidth: 1.5,
+          order: 1,
+        },
+      ],
+    };
+
+    return { chartData, markerEvent, markerEventIdx };
+  }, [data, selectedIdx]);
+
+  const selectEvent = (evIdx: number | null) => {
+    setSelectedIdx(evIdx);
+    if (evIdx != null && listRef.current) {
+      listRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  };
+
+  const options = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'nearest' as const, intersect: true },
+    onClick: (_evt: any, elements: any[]) => {
+      const hit = elements.find((el) => el.datasetIndex === 1);
+      if (hit && chart) {
+        const evIdx = chart.markerEventIdx[hit.index];
+        selectEvent(evIdx ?? null);
+      }
+    },
+    plugins: {
+      legend: { display: false },
+      title: {
+        display: true,
+        text: resolvedName ? `${resolvedName} — 최근 1년 주가와 사건` : '주가와 사건',
+        font: { size: 14 },
+      },
+      tooltip: {
+        callbacks: {
+          title: (items: any[]) => {
+            const it = items[0];
+            if (it?.datasetIndex === 1 && chart) {
+              const ev = chart.markerEvent[it.dataIndex];
+              return ev ? `${ev.date} · ${ev.headline}` : it.label;
+            }
+            return it?.label ?? '';
+          },
+          label: (ctx: any) => {
+            if (ctx.datasetIndex === 1 && chart) {
+              const ev = chart.markerEvent[ctx.dataIndex];
+              if (!ev) return '';
+              const pct = ev.pct_change == null ? '주가 영향 미미' : `${ev.pct_change > 0 ? '+' : ''}${ev.pct_change}%`;
+              return `${ev.category} · ${pct}`;
+            }
+            return `종가: ${Number(ctx.parsed.y).toLocaleString()}원`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        title: { display: true, text: '종가 (원)' },
+        ticks: { callback: (v: string | number) => Number(v).toLocaleString() },
+      },
+      x: {
+        ticks: { maxTicksLimit: 8, autoSkip: true, maxRotation: 0 },
+      },
+    },
+  }), [chart, resolvedName]);
 
   const isError = message.startsWith('오류');
   const starred = resolvedName && isFavorite ? isFavorite(resolvedName, PAGE_KEY) : false;
@@ -131,8 +297,8 @@ export default function EventsPage({
     <div className="p-6 bg-gray-50 min-h-screen">
       <h1 className="text-2xl font-bold text-gray-800 mb-1">주가를 움직인 사건들</h1>
       <p className="text-sm text-gray-500 mb-6">
-        최근 1년간 밸류에이션·투자 내러티브에 유의미한 사건을 AI가 검색합니다.
-        주가가 실제로 크게 움직이지 않았어도 포함될 수 있어요.
+        최근 1년간 밸류에이션·투자 내러티브에 유의미한 사건을 AI가 검색해 주가 그래프 위에 표시합니다.
+        마커나 아래 카드를 클릭하면 서로 연동됩니다.
       </p>
 
       {/* 검색 */}
@@ -176,11 +342,24 @@ export default function EventsPage({
         </p>
       )}
 
+      {chart && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 max-w-3xl mb-5">
+          <div className="h-72">
+            <Line options={options} data={chart.chartData} />
+          </div>
+        </div>
+      )}
+
       {data && (
         data.events.length > 0 ? (
-          <div className="flex flex-col gap-3 max-w-3xl">
+          <div ref={listRef} className="flex flex-col gap-3 max-w-3xl">
             {data.events.map((event, i) => (
-              <EventCard key={i} event={event} />
+              <EventCard
+                key={i}
+                event={event}
+                open={selectedIdx === i}
+                onToggle={() => selectEvent(selectedIdx === i ? null : i)}
+              />
             ))}
           </div>
         ) : (

--- a/simple_fast_api/services/events.py
+++ b/simple_fast_api/services/events.py
@@ -61,6 +61,17 @@ def _fetch_price_history(company_name: str):
     return None
 
 
+def _serialize_prices(hist) -> list[dict]:
+    """일별 종가 시계열을 [{date, close}] 형태로 직렬화합니다. 시세가 없으면 빈 리스트."""
+    if hist is None or hist.empty:
+        return []
+    return [
+        {"date": d.strftime("%Y-%m-%d"), "close": round(float(c), 2)}
+        for d, c in zip(hist.index, hist["Close"])
+        if c == c  # NaN 제외
+    ]
+
+
 def _price_change_near(hist, date_str: str | None) -> float | None:
     """이벤트 날짜 전후 거래일 등락률(참고용). 계산 불가 시 None."""
     if hist is None or hist.empty or not date_str:
@@ -74,6 +85,14 @@ def _price_change_near(hist, date_str: str | None) -> float | None:
     if start_price <= 0:
         return None
     return round((end_price - start_price) / start_price * 100, 1)
+
+
+def _anchor_date_near(hist, date_str: str | None) -> str | None:
+    """이벤트 날짜 이후 첫 거래일을 반환합니다(차트 마커 고정용). 매칭 불가 시 None."""
+    if hist is None or hist.empty or not date_str:
+        return None
+    dates = [d.strftime("%Y-%m-%d") for d in hist.index]
+    return next((d for d in dates if d >= date_str), dates[-1])
 
 
 def _parse_json_object(text: str) -> dict | None:
@@ -186,14 +205,15 @@ async def analyze_price_events(company_name: str) -> dict:
 
     articles = await _gather_recent_articles(company_name)
     if not articles:
-        return {"company_name": company_name, "events": []}
+        return {"company_name": company_name, "events": [], "prices": _serialize_prices(hist)}
 
     events = await _select_events(company_name, articles)
     for e in events:
         e["pct_change"] = _price_change_near(hist, e.get("date"))
+        e["anchor_date"] = _anchor_date_near(hist, e.get("date"))
 
     importance_rank = {"high": 0, "medium": 1, "low": 2}
     events.sort(key=lambda e: e.get("date") or "", reverse=True)
     events.sort(key=lambda e: importance_rank.get(e.get("importance", "medium"), 1))
 
-    return {"company_name": company_name, "events": events}
+    return {"company_name": company_name, "events": events, "prices": _serialize_prices(hist)}


### PR DESCRIPTION
## 요약

`/events`(주가를 움직인 사건들) 기능에서, AI가 선별한 뉴스·공시 사건을 **주가 그래프 위에 마커로 표시**하도록 연동했습니다. 이전에는 사건이 카드 목록으로만 나왔고 주가 시세는 백엔드에서 `pct_change` 계산에만 쓰고 버려졌습니다.

## 변경 내용

### 백엔드 (`simple_fast_api/services/events.py`)
- `_serialize_prices()` 추가 — 1년치 일별 종가 시계열을 `[{date, close}]`로 직렬화 (NaN 제외).
- `_anchor_date_near()` 추가 — 각 사건 날짜를 **이후 첫 거래일**로 앵커링해 차트 마커 위치를 시세 포인트에 정확히 맞춤 (주말·휴일 보정).
- `analyze_price_events()`가 응답에 `prices`(시계열)를 포함하고, 각 이벤트에 `anchor_date`를 부여. 사건이 없는 경로에서도 `prices`를 반환.
- `/events` 라우트·캐시는 결과 dict를 그대로 통과시키므로 별도 수정 불필요.

### 프론트엔드 (`frontend/next/src/app/events/page.tsx`)
- Chart.js 라인 차트를 추가해 최근 1년 종가 위에 사건을 마커로 오버레이 (dividend 페이지의 Chart.js 컨벤션 준수).
- 마커 색상은 중요도(high=amber / medium=blue)로 구분, 툴팁에 사건 제목·카테고리·등락률 표시.
- **마커 ↔ 카드 양방향 연동**: 마커를 클릭하면 해당 카드가 열리고, 카드를 클릭하면 마커가 강조됩니다 (`selectedIdx` 상태 공유).

## 검증
- 백엔드: 합성 가격 프레임으로 `_serialize_prices`(NaN 제외·형태), `_anchor_date_near`(다음 거래일/당일/None), `_price_change_near` 단위 검증 통과. `py_compile` OK.
- 프론트: `events/page.tsx` ESLint·`tsc --noEmit` 무오류 (리포트된 lint 오류는 이 브랜치가 건드리지 않은 기존 파일 `InteractiveLayout.js`·`dividend/page.tsx`의 선반영 이슈).
- 라이브 `/events` 호출은 이 환경의 아웃바운드 정책이 DART·yfinance·Naver 호스트를 차단(프록시 403)하여 완주 불가 — 코드 이슈가 아니라 환경 제약이며, 배포 환경에서는 도달 가능합니다. `NAVER_CLIENT_ID/SECRET`·`GROQ_API_KEY`가 있어야 사건 선별 절반이 동작합니다(시세·마커 표시는 yfinance만 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxxyoeQPYXappdBTAJo3Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxxyoeQPYXappdBTAJo3Yy)_